### PR TITLE
Update documentation reference link in sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [References](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
This pull request makes a minor update to the documentation sidebar by renaming one of the links for clarity and correcting its target file.

* Renamed the sidebar link from "Documentation references" to "References" and updated the link to point to `doc-references.md` instead of `doc-references__.md`.